### PR TITLE
Edge Case: Compound before initial deposit

### DIFF
--- a/src/mock_nominator/lib.rs
+++ b/src/mock_nominator/lib.rs
@@ -9,8 +9,6 @@ mod mock_nominator {
     use crate::traits::INominationAgent;
     use ink::env::Error as EnvError;
 
-    const BIPS: u128 = 10000;
-
     #[ink(storage)]
     pub struct NominationAgent {
         vault: AccountId,
@@ -112,7 +110,7 @@ mod mock_nominator {
                 return Err(RuntimeError::Unauthorized);
             }
 
-            let compound_amount = Self::env().balance();
+            let compound_amount = Self::env().balance() - self.staked - self.unbonding;
 
             // Gracefully return when nomination agent has no rewards
             if compound_amount == 0 {

--- a/src/vault/lib.rs
+++ b/src/vault/lib.rs
@@ -599,13 +599,14 @@ mod vault {
         /// Calculate the value of AZERO in terms of sA0 shares
         #[ink(message)]
         fn get_shares_from_azero(&self, azero: Balance) -> u128 {
-            let total_pooled_ = self.data.total_pooled; // shadow
-            if total_pooled_ == 0 {
+            let total_pooled = self.data.total_pooled; // shadow
+            let total_shares = self.get_total_shares(); // shadow
+            if total_pooled == 0 || total_shares == 0 {
                 // This happens upon initial stake
                 // Also known as 1:1 redemption ratio
                 azero
             } else {
-                self.data.pro_rata(azero, self.get_total_shares(), total_pooled_)
+                self.data.pro_rata(azero, total_shares, total_pooled)
             }
         }
 


### PR DESCRIPTION
Fixes an edge case where no shares are minted if a compound happens before the first deposit