### PR TITLE
Remove Extra Existential Deposit

### DIFF
--- a/drink_tests/helpers.rs
+++ b/drink_tests/helpers.rs
@@ -45,7 +45,6 @@ pub fn call_add_agent(
     admin: &AccountId32,
     validator: &AccountId32,
     pool_create_amount: u128,
-    existential_deposit: u128,
 ) -> Result<(AccountId32, Session<MinimalRuntime>), Box<dyn Error>> {
     let sess: Session<MinimalRuntime> = call_function(
         sess,
@@ -55,10 +54,8 @@ pub fn call_add_agent(
         Some([
             admin.to_string(),
             validator.to_string(),
-            pool_create_amount.to_string(),
-            existential_deposit.to_string(),
         ].to_vec()),
-        Some(pool_create_amount + existential_deposit),
+        Some(pool_create_amount),
         transcoder_registry(),
     )?;
 

--- a/drink_tests/lib.rs
+++ b/drink_tests/lib.rs
@@ -106,7 +106,6 @@ mod tests {
             &bob,
             &validator1,
             100e12 as u128,
-            500,
         )?;
         let (_new_agent, sess) = helpers::call_add_agent(
             sess,
@@ -115,7 +114,6 @@ mod tests {
             &bob,
             &validator2,
             100e12 as u128,
-            500,
         )?;
 
         let (_, agents, sess) = helpers::get_agents(sess, &registry)?;
@@ -686,7 +684,6 @@ mod tests {
             &ctx.charlie,
             &ctx.validators[2],
             100e12 as u128,
-            500,
         ) {
             Ok(_) => panic!("Should panic because caller is restricted"),
             Err(_) => (),
@@ -794,7 +791,6 @@ mod tests {
             &ctx.bob,
             &ctx.validators[2],
             100e12 as u128,
-            500,
         )?;
 
         let (total_weight_after, agents_after, sess) = helpers::get_agents(
@@ -865,7 +861,6 @@ mod tests {
             &ctx.bob,
             &ctx.validators[2],
             100e12 as u128,
-            500,
         )?;
 
         let (total_weight_after, agents_after, sess) = helpers::get_agents(

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -32,10 +32,6 @@ const main = async (validators: string[]) => {
   const minNominatorBond = BigInt(minNominatorBondCodec.toString())
   console.log(`Minimum nomination bond: ${minNominatorBond}`)
 
-  const existentialDepositCodec = api.consts.balances.existentialDeposit
-  const existentialDeposit = BigInt(existentialDepositCodec.toString())
-  console.log(`Existential deposit: ${existentialDeposit}`)
-
   const sessionPeriod = api.consts.committeeManagement.sessionPeriod.toString().replace(/,/g, '')
   const sessionsPerEra = api.consts.staking.sessionsPerEra.toString().replace(/,/g, '')
   const eraDurationMs = 1000n * BigInt(sessionPeriod) * BigInt(sessionsPerEra)
@@ -132,9 +128,9 @@ const main = async (validators: string[]) => {
       registry_instance,
       'add_agent',
       {
-        value: minNominatorBond + existentialDeposit,
+        value: minNominatorBond,
       },
-      [account.address, validator, minNominatorBond, existentialDeposit],
+      [account.address, validator],
     )
   }
 

--- a/src/mock_nominator/lib.rs
+++ b/src/mock_nominator/lib.rs
@@ -51,13 +51,13 @@ mod mock_nominator {
             vault: AccountId,
             admin: AccountId,
             validator: AccountId,
-            creation_bond: u128,
-            existential_deposit: u128,
         ) -> Self {
+            let creation_bond = Self::env().transferred_value();
+
             // Mock spending AZERO to create agent
             Self::env().transfer(
                 AccountId::from([0u8; 32]),
-                creation_bond + existential_deposit,
+                creation_bond,
             ).unwrap();
 
             Self {

--- a/src/nomination_agent/lib.rs
+++ b/src/nomination_agent/lib.rs
@@ -53,12 +53,8 @@ mod nomination_agent {
             vault: AccountId,
             admin: AccountId,
             validator: AccountId,
-            creation_bond: u128,
-            existential_deposit: u128,
         ) -> Self {
-            if Self::env().transferred_value() != creation_bond + existential_deposit {
-                panic!("Insufficient transferred value");
-            }
+            let creation_bond = Self::env().transferred_value();
 
             let nomination_agent = NominationAgent {
                 vault,

--- a/src/registry/lib.rs
+++ b/src/registry/lib.rs
@@ -184,10 +184,9 @@ pub mod registry {
             &mut self,
             admin: AccountId,
             validator: AccountId,
-            nominator_bond: Balance,
-            existential_deposit: Balance,
         ) -> Result<AccountId, RegistryError> {
             let caller = Self::env().caller();
+            let nominator_bond = Self::env().transferred_value();
 
             if caller != self.roles.get(RoleType::AddAgent).unwrap().account {
                 return Err(RegistryError::InvalidPermissions);
@@ -199,10 +198,8 @@ pub mod registry {
                 self.vault,
                 admin,
                 validator,
-                nominator_bond,
-                existential_deposit,
             )
-            .endowment(nominator_bond + existential_deposit)
+            .endowment(nominator_bond)
             .code_hash(self.nomination_agent_hash)
             .salt_bytes(nomination_agent_counter.to_le_bytes())
             .instantiate();

--- a/src/registry/traits.rs
+++ b/src/registry/traits.rs
@@ -3,13 +3,11 @@ use ink::{prelude::vec::Vec, primitives::AccountId};
 
 #[ink::trait_definition]
 pub trait Registry {
-    #[ink(message, selector = 1)]
+    #[ink(message, payable, selector = 1)]
     fn add_agent(
         &mut self,
         admin: AccountId,
         validator: AccountId,
-        pool_create_amount: u128,
-        existential_deposit: u128,
     ) -> Result<(), RegistryError>;
     #[ink(message, selector = 2)]
     fn update_agents(


### PR DESCRIPTION
An existential deposit quantity of AZERO was transferred when adding an agent because an additional nomination pool used to be created. This is no longer the case and leads to 1000 free balance in the agents (instead of 500)