### PR TITLE
Added lock functionality for Governance NFT transfers 

### DIFF
--- a/governance_tests/helpers.rs
+++ b/governance_tests/helpers.rs
@@ -63,6 +63,8 @@ pub enum PropType {
     UpdateRejectThreshhold(u128),
     UpdateExecThreshhold(u128),
     SetCodeHash([u8; 32]),
+    UnlockTransfer(),
+    LockTransfer(),
 }
 #[derive(Debug, PartialEq, Eq, scale::Encode, Clone, scale::Decode)]
 #[cfg_attr(

--- a/governance_tests/lib.rs
+++ b/governance_tests/lib.rs
@@ -1897,4 +1897,45 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn unlock_nft_proposal() -> Result<(), Box<dyn Error>> {
+        let mut ctx = setup(ACC_THRESHOLD, REJECT_THRESHOLD, EXEC_THRESHOLD).unwrap();
+        ctx = wrap_tokens(ctx, TOTAL_SUPPLY / 10).unwrap();
+
+        let sess = call_function(
+            ctx.sess,
+            &ctx.gov_nft,
+            &ctx.alice,
+            String::from("is_collection_locked"),
+            Some(vec![]),
+            None,
+            transcoder_governance_nft(),
+        )
+        .unwrap();
+
+        let rr: Result<bool, drink::errors::LangError> = sess.last_call_return().unwrap();
+        let transfer_status = rr.unwrap();
+
+        assert_eq!(transfer_status, true);
+
+        let sess = call_function(
+            sess,
+            &ctx.governance,
+            &ctx.alice,
+            String::from("create_proposal"),
+            Some(vec![helpers::PropType::UnlockTransfer().to_string(), 1.to_string()]),
+            None,
+            transcoder_governance(),
+        )
+        .unwrap();
+
+        // let rr: Result<helpers::Proposal, drink::errors::LangError> = sess.last_call_return().unwrap();
+        // let proposal = rr.unwrap();
+
+    // When retrieving the proposal it returns None
+    // let (proposal, sess) = helpers::query_governance_get_proposal_by_nft(sess, &ctx.governance, 1_u128).unwrap();
+    // let proposal_string: String = proposal.prop_id.to_string();
+    Ok(())
+    }
 }

--- a/src/governance/lib.rs
+++ b/src/governance/lib.rs
@@ -43,6 +43,9 @@ pub mod governance {
         StakingError,
         TokenError(PSP22Error),
         InkEnvError(String),
+        TransferLockError,
+        TransferAlreadyUnlocked,
+        TransferAlreadyLocked,
     }
     impl From<InkEnvError> for GovernanceError {
         fn from(e: InkEnvError) -> Self {
@@ -85,6 +88,10 @@ pub mod governance {
         UpdateExecThreshhold(u128),
 
         SetCodeHash([u8; 32]),
+        // Unlock Transfer for governance nft
+        UnlockTransfer(),
+        // Lock Transfer for governance nft
+        LockTransfer(),
     }
     #[derive(Debug, PartialEq, Eq, scale::Encode, Clone, scale::Decode)]
     #[cfg_attr(
@@ -315,6 +322,27 @@ pub mod governance {
             ink::env::set_code_hash(&code_hash)?;
             Ok(())
         }
+
+        fn unlock_transfer(&self) -> Result<(), GovernanceError> {
+            let mut gov_nft: contract_ref!(GovernanceNFT) = self.gov_nft.into();
+            if gov_nft.is_collection_locked() == false {
+                return Err(GovernanceError::TransferAlreadyUnlocked)
+            }
+            if let Err(e) = gov_nft.unlock_transfer(){
+                return Err(GovernanceError::TransferLockError)
+            }
+            Ok(())
+        }
+        fn lock_transfer(&self) -> Result<(), GovernanceError> {
+            let mut gov_nft: contract_ref!(GovernanceNFT) = self.gov_nft.into();
+            if gov_nft.is_collection_locked() == true {
+                return Err(GovernanceError::TransferAlreadyLocked)
+            }
+            if let Err(e) = gov_nft.lock_transfer(){
+                return Err(GovernanceError::TransferLockError)
+            }
+            Ok(())
+        }
         /**
          // Transfer Azero from governance
         TransferFunds(TokenTransfer),
@@ -399,6 +427,10 @@ pub mod governance {
                         self.update_staking_rewards(*new_rate)?
                     }
                     PropType::SetCodeHash(code_hash) => self.set_code_internal(*code_hash)?,
+
+                    PropType::UnlockTransfer() => self.unlock_transfer()?,
+
+                    PropType::LockTransfer() => self.lock_transfer()?,
                 };
                 Self::emit_event(
                     Self::env(),

--- a/src/governance_nft/lib.rs
+++ b/src/governance_nft/lib.rs
@@ -49,6 +49,7 @@ mod governance_nft {
         admin: AccountId,
         mint_count: u128,
         token_governance_data: Mapping<u128, GovernanceData>,
+        lock_transfer: bool,
     }
 
     impl GovernanceNFT {
@@ -60,6 +61,7 @@ mod governance_nft {
                 admin: _admin,
                 mint_count: 0_u128,
                 token_governance_data: Mapping::default(), // (8)
+                lock_transfer: true,
             }
         }
 
@@ -89,6 +91,30 @@ mod governance_nft {
                 }
             }
         }
+
+        #[ink(message)]
+        pub fn lock_transfer(&mut self) -> Result<(), PSP34Error> {
+            if self.env().caller() != self.admin {
+                return Err(PSP34Error::Custom(String::from("Unauthorized")));
+            }
+            self.lock_transfer = true;
+            Ok(())
+        }
+
+        #[ink(message)]
+        pub fn unlock_transfer(&mut self) -> Result<(), PSP34Error> {
+            if self.env().caller() != self.admin {
+                return Err(PSP34Error::Custom(String::from("Unauthorized")));
+            }
+            self.lock_transfer = false;
+            Ok(())
+        }
+
+        #[ink(message, selector = 69)]
+        pub fn is_collection_locked(&self) -> bool {
+            self.lock_transfer
+        }
+
         #[ink(message, selector = 7)]
         pub fn transfer_from(
             &mut self,
@@ -98,6 +124,9 @@ mod governance_nft {
             data: ink::prelude::vec::Vec<u8>,
         ) -> Result<(), PSP34Error> {
             let events = self.data.transfer(from, to, id, data)?;
+            if self.lock_transfer == true {
+                return Err(PSP34Error::Custom(String::from("Token transfer is locked")));
+            }
             self.emit_events(events);
             Ok(())
         }
@@ -248,6 +277,9 @@ mod governance_nft {
             data: ink::prelude::vec::Vec<u8>,
         ) -> Result<(), PSP34Error> {
             let events = self.data.transfer(self.env().caller(), to, id, data)?;
+            if self.lock_transfer == true {
+                return Err(PSP34Error::Custom(String::from("Token transfer is locked")));
+            }
             self.emit_events(events);
             Ok(())
         }

--- a/src/governance_nft/traits.rs
+++ b/src/governance_nft/traits.rs
@@ -13,6 +13,12 @@ pub trait GovernanceNFT{
     fn increment_weight(&mut self,id:u128,weight:u128) -> Result<(), PSP34Error>;
     #[ink(message, selector = 77)]
     fn decrement_weight(&mut self,id:u128,weight:u128) -> Result<(), PSP34Error>;
+    #[ink(message)]
+    fn unlock_transfer(&mut self) -> Result<(), PSP34Error>;
+    #[ink(message)]
+    fn lock_transfer(&mut self) -> Result<(), PSP34Error>;
+    #[ink(message, selector = 69)]
+    fn is_collection_locked(&self) -> bool;
     #[ink(message, selector = 17)]
     fn transfer_from(
         &mut self,


### PR DESCRIPTION
The transfer functions are now locked. The functions can be unlocked or re-locked through a governance proposal