### PR TITLE
30 Max Agents

### DIFF
--- a/drink_tests/lib.rs
+++ b/drink_tests/lib.rs
@@ -765,7 +765,8 @@ mod tests {
     fn test_nominator_addition_panic_because_too_many_agents() {
         let ctx = setup().unwrap();
 
-        const MAX_AGENTS: usize = 20;
+        // Defined in Registry
+        const MAX_AGENTS: usize = 30;
 
         let (_, agents_before, mut sess) = helpers::get_agents(ctx.sess, &ctx.registry).unwrap();
         let prior_agent_count = agents_before.len();

--- a/src/registry/lib.rs
+++ b/src/registry/lib.rs
@@ -23,7 +23,7 @@ pub mod registry {
         }
     }
 
-    pub const MAX_AGENTS: usize = 20;
+    pub const MAX_AGENTS: usize = 30;
 
     #[derive(Debug, PartialEq, Eq, Clone, scale::Encode, scale::Decode)]
     #[cfg_attr(


### PR DESCRIPTION
not safe for default local node settings
safe for alephzero & alephzero-testnet
